### PR TITLE
Fix import statement in ChatContext

### DIFF
--- a/src/contexts/ChatContext.tsx
+++ b/src/contexts/ChatContext.tsx
@@ -1,7 +1,6 @@
-
 import React, { createContext, useContext, useReducer, useEffect, useRef } from 'react';
 import { AIMessage, ChatService, FileAttachment } from '@/services/chat/types';
-import { getChatService } from '@/services/chat/googleGenAIService';
+import { getChatService } from '@/services/chat/googleGenAIService.tsx';
 import { toast } from '@/components/ui/use-toast';
 import { chatReducer } from './chat/chatReducer';
 import { ChatContextType, initialChatState } from './chat/types';


### PR DESCRIPTION
Update import statement in `src/contexts/ChatContext.tsx` to reference the correct file.

* Change the import statement to `import { getChatService } from '@/services/chat/googleGenAIService.tsx'` to fix the missing file error during build.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iamfarzad/fbconsulting/pull/21?shareId=9adeacf7-80ce-4b50-80ae-15150e367e70).