### PR TITLE
Add tests for useConnectionStatus hook

### DIFF
--- a/src/hooks/__tests__/useConnectionStatus.test.ts
+++ b/src/hooks/__tests__/useConnectionStatus.test.ts
@@ -1,0 +1,68 @@
+import { renderHook, act } from '@testing-library/react-hooks';
+import { useConnectionStatus } from '../useConnectionStatus';
+
+describe('useConnectionStatus', () => {
+  beforeAll(() => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+      })
+    );
+  });
+
+  afterAll(() => {
+    global.fetch.mockClear();
+  });
+
+  it('should return initial connection status as false', () => {
+    const { result } = renderHook(() => useConnectionStatus());
+    expect(result.current.isConnected).toBe(false);
+  });
+
+  it('should return connection status as true if API key is present', () => {
+    const mockApiKey = 'mock-api-key';
+    jest.spyOn(require('@/config/api'), 'apiConfig', 'get').mockReturnValue({ geminiApiKey: mockApiKey });
+
+    const { result } = renderHook(() => useConnectionStatus());
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('should check health status if API key is not present', async () => {
+    jest.spyOn(require('@/config/api'), 'apiConfig', 'get').mockReturnValue({ geminiApiKey: null });
+
+    const { result, waitForNextUpdate } = renderHook(() => useConnectionStatus());
+
+    await waitForNextUpdate();
+
+    expect(global.fetch).toHaveBeenCalledWith('/api/health');
+    expect(result.current.isConnected).toBe(true);
+  });
+
+  it('should update connection status based on health check response', async () => {
+    jest.spyOn(require('@/config/api'), 'apiConfig', 'get').mockReturnValue({ geminiApiKey: null });
+
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: false,
+      })
+    );
+
+    const { result, waitForNextUpdate } = renderHook(() => useConnectionStatus());
+
+    await waitForNextUpdate();
+
+    expect(result.current.isConnected).toBe(false);
+
+    global.fetch.mockImplementationOnce(() =>
+      Promise.resolve({
+        ok: true,
+      })
+    );
+
+    await act(async () => {
+      await waitForNextUpdate();
+    });
+
+    expect(result.current.isConnected).toBe(true);
+  });
+});


### PR DESCRIPTION
Add tests for the `useConnectionStatus` hook.

* **Initial Connection Status**: Check that the initial connection status is false.
* **API Key Presence**: Verify that the connection status is true if an API key is present.
* **Health Check**: Test health status check if the API key is not present.
* **Connection Status Update**: Update connection status based on health check response.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/iamfarzad/fbconsulting/pull/29?shareId=8ab40df3-220b-4c62-93f5-d08586a4486d).